### PR TITLE
Fixed compiler error on Xcode 6.1 for NilLiteralConvertible protocol conformance.

### DIFF
--- a/Snappy/ConstraintAttributes.swift
+++ b/Snappy/ConstraintAttributes.swift
@@ -38,6 +38,9 @@ internal struct ConstraintAttributes: RawOptionSetType, BooleanType {
     internal init(_ rawValue: UInt) {
         self.init(rawValue: rawValue)
     }
+    internal init(nilLiteral: ()) {
+        self.rawValue = 0
+    }
     
     internal private(set) var rawValue: UInt
     internal static var allZeros: ConstraintAttributes { return self(0) }


### PR DESCRIPTION
Small change needed. It was simply missing the NilLiteralConvertible initializer.
