### PR TITLE
Fix snp_makeConstraints clobering existing constraints

### DIFF
--- a/Snappy/ConstraintMaker.swift
+++ b/Snappy/ConstraintMaker.swift
@@ -70,7 +70,7 @@ public class ConstraintMaker {
         let maker = ConstraintMaker(view: view)
         block(make: maker)
         
-        var layoutConstraints: Array<LayoutConstraint> = []
+        var layoutConstraints = LayoutConstraint.layoutConstraintsInstalledOnView(view)
         for constraint in maker.constraints {
             layoutConstraints += constraint.install()
         }


### PR DESCRIPTION
I believe this fixes a bug with `makeConstraints` clobbering old constraints and thus breaking subsequent calls to remakeConstraints.

I have a project with custom tableviewcells, and I replicated a disclosure indicator. After updating my constraints for this view being in the hierarchy or not I noticed autlayout was complaining that my normal content wrapper and the disclosure image both had constraints to the tableview cell right (along with the content being constrained to the image) and couldn't resolve it. 

I was essentially doing

```
self.contentWrapper.snp_remakeConstraints { make in
    if (self.showsDisclosure) {
        make.right.equalTo(self.disclosureView.snp_left)
    } else { 
        make.right.equalTo(self.contentView.snp_right)
    }
}

... later ...

self.contentWrapper.snp_makeConstraints { make in
     make.height.equalTo(newHeight)
     make.centerY.equalTo(self.snp_centerY)
}
```

Stepping through this a second time, remakeConstraints wasn't removing the previously set right constraint because makeConstraints was clobbering it
