### PR TITLE
Replace constraints when update to different relationship.

### DIFF
--- a/Snap.xcodeproj/project.pbxproj
+++ b/Snap.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0364732D1A64086800E1F188 /* UpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0364732C1A64086800E1F188 /* UpdateTests.swift */; };
+		0364732E1A6408F200E1F188 /* SnapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE91728C19CB304E007888CF /* SnapTests.swift */; };
+		0364732F1A64090E00E1F188 /* View+Snap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F119CC65040083B827 /* View+Snap.swift */; };
+		036473301A64090E00E1F188 /* ConstraintMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9FB19CC65430083B827 /* ConstraintMaker.swift */; };
+		036473311A64090E00E1F188 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9FF19CC66020083B827 /* Constraint.swift */; };
+		036473321A64090E00E1F188 /* ConstraintItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F719CC65260083B827 /* ConstraintItem.swift */; };
+		036473331A64090E00E1F188 /* ConstraintAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F319CC65110083B827 /* ConstraintAttributes.swift */; };
+		036473341A64090E00E1F188 /* ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F519CC65200083B827 /* ConstraintRelation.swift */; };
+		036473351A64090E00E1F188 /* LayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9FD19CC65510083B827 /* LayoutConstraint.swift */; };
+		036473361A64090E00E1F188 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9EF19CC64F70083B827 /* EdgeInsets.swift */; };
 		EEBCC9F019CC64F80083B827 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9EF19CC64F70083B827 /* EdgeInsets.swift */; };
 		EEBCC9F219CC65050083B827 /* View+Snap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F119CC65040083B827 /* View+Snap.swift */; };
 		EEBCC9F419CC65110083B827 /* ConstraintAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBCC9F319CC65110083B827 /* ConstraintAttributes.swift */; };
@@ -18,6 +28,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0364732C1A64086800E1F188 /* UpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateTests.swift; sourceTree = "<group>"; };
 		EE91728119CB304E007888CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EE91728219CB304E007888CF /* Snap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Snap.h; sourceTree = "<group>"; };
 		EE91728B19CB304E007888CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -99,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				EE91728C19CB304E007888CF /* SnapTests.swift */,
+				0364732C1A64086800E1F188 /* UpdateTests.swift */,
 				EE91728A19CB304E007888CF /* Supporting Files */,
 			);
 			path = SnapTests;
@@ -233,6 +245,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0364732F1A64090E00E1F188 /* View+Snap.swift in Sources */,
+				036473301A64090E00E1F188 /* ConstraintMaker.swift in Sources */,
+				036473311A64090E00E1F188 /* Constraint.swift in Sources */,
+				036473321A64090E00E1F188 /* ConstraintItem.swift in Sources */,
+				036473331A64090E00E1F188 /* ConstraintAttributes.swift in Sources */,
+				036473341A64090E00E1F188 /* ConstraintRelation.swift in Sources */,
+				036473351A64090E00E1F188 /* LayoutConstraint.swift in Sources */,
+				036473361A64090E00E1F188 /* EdgeInsets.swift in Sources */,
+				0364732D1A64086800E1F188 /* UpdateTests.swift in Sources */,
+				0364732E1A6408F200E1F188 /* SnapTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -363,6 +385,7 @@
 		EEBCC9EC19CC627E0083B827 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -375,12 +398,14 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		EEBCC9ED19CC627E0083B827 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -382,15 +382,28 @@ public class Constraint {
                 
                 // loop through existing and check for match
                 for existingLayoutConstraint in existingLayoutConstraints {
-                    if existingLayoutConstraint == layoutConstraint {
+                    if existingLayoutConstraint.isSimilarTo(layoutConstraint) {
                         updateLayoutConstraint = existingLayoutConstraint
                         break
                     }
                 }
-                
-                // if we have existing one lets just update the constant
-                if updateLayoutConstraint != nil {
-                    updateLayoutConstraint!.constant = layoutConstraint.constant
+
+                // if we have existing one
+                if let updateLayoutConstraint = updateLayoutConstraint {
+                    // if existing one is same with new one, updates constant and priority if needed.
+                    if updateLayoutConstraint == layoutConstraint {
+                        if updateLayoutConstraint.constant != layoutConstraint.constant {
+                            updateLayoutConstraint.constant = layoutConstraint.constant
+                        }
+                        if updateLayoutConstraint.priority != layoutConstraint.priority {
+                            updateLayoutConstraint.priority = layoutConstraint.priority
+                        }
+                    }
+                    // if new constraint is not same with existing but has same attributes, replace existing with new one.
+                    else {
+                        updateLayoutConstraint.constraint!.uninstall()
+                        newLayoutConstraints.append(layoutConstraint)
+                    }
                 }
                 // otherwise add this layout constraint to new list
                 else {

--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -437,9 +437,15 @@ public class Constraint {
                     }
                 }
             }
-            if constraintsToRemove.count > 0 {
-                view.removeConstraints(constraintsToRemove)
+            for constraintToRemove in constraintsToRemove {
+                let firstItem = constraintToRemove.firstItem as View
+                var installedLayoutConstraints = firstItem.snp_installedLayoutConstraints
+                if let i = find(installedLayoutConstraints, constraintToRemove) {
+                    installedLayoutConstraints.removeAtIndex(i)
+                    firstItem.snp_installedLayoutConstraints = installedLayoutConstraints
+                }
             }
+            view.removeConstraints(constraintsToRemove)
         }
         self.installedOnView = nil
     }

--- a/Snap/ConstraintMaker.swift
+++ b/Snap/ConstraintMaker.swift
@@ -108,13 +108,13 @@ public class ConstraintMaker {
         #endif
         let maker = ConstraintMaker(view: view)
         block(make: maker)
-        
-        var layoutConstraints = view.snp_installedLayoutConstraints
+
+        var newLayoutConstraints = [LayoutConstraint]()
         for constraint in maker.constraints {
-            layoutConstraints += constraint.install(updateExisting: true)
+            newLayoutConstraints += constraint.install(updateExisting: true)
         }
-        
-        view.snp_installedLayoutConstraints = layoutConstraints
+
+        view.snp_installedLayoutConstraints = view.snp_installedLayoutConstraints + newLayoutConstraints
     }
     
     internal class func removeConstraints(view: View) {

--- a/Snap/LayoutConstraint.swift
+++ b/Snap/LayoutConstraint.swift
@@ -32,22 +32,29 @@ import AppKit
 */
 public class LayoutConstraint: NSLayoutConstraint {
     internal var constraint: Constraint?
+
+    func isSimilarTo(layoutConstraint: LayoutConstraint) -> Bool {
+        if self.firstItem !== layoutConstraint.firstItem {
+            return false
+        }
+        if self.firstAttribute != layoutConstraint.firstAttribute {
+            return false
+        }
+        if self.relation != layoutConstraint.relation {
+            return false
+        }
+        return true
+    }
 }
 
 public func ==(left: LayoutConstraint, right: LayoutConstraint) -> Bool {
-    if left.firstItem !== right.firstItem {
+    if !left.isSimilarTo(right) {
         return false
     }
     if left.secondItem !== right.secondItem {
         return false
     }
-    if left.firstAttribute != right.firstAttribute {
-        return false
-    }
     if left.secondAttribute != right.secondAttribute {
-        return false
-    }
-    if left.relation != right.relation {
         return false
     }
     if left.priority != right.priority {

--- a/SnapTests/UpdateTests.swift
+++ b/SnapTests/UpdateTests.swift
@@ -1,0 +1,122 @@
+//
+//  UpdateTests.swift
+//  Snap
+//
+//  Created by 전수열 on 1/12/15.
+//  Copyright (c) 2015 Jonas Budelmann. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+#if os(iOS)
+import UIKit
+#else
+import AppKit
+#endif
+
+class UpdateTests: XCTestCase {
+
+    var superview: View!
+    var view1: View!
+    var view2: View!
+
+    override func setUp() {
+        super.setUp()
+        self.superview = View(frame: CGRect(x: 0, y: 0, width: 400, height: 400))
+        self.view1 = View(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+        self.superview.addSubview(self.view1)
+        self.view2 = View(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        self.superview.addSubview(self.view2)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testUpdateConstant() {
+        self.view1.snp_makeConstraints { make in
+            make.width.equalTo(100)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        self.view1.snp_updateConstraints { make in
+            make.width.equalTo(200)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        XCTAssert(CGRectGetWidth(self.view1.frame) == 200)
+        XCTAssert(self.view1.snp_installedLayoutConstraints.count == 1)
+    }
+
+    func testUpdatePriority() {
+        self.view1.snp_makeConstraints { make in
+            make.width.equalTo(self.superview).with.priority(100)
+            make.width.equalTo(self.view2).with.priority(500)
+        }
+        self.view1.layoutIfNeeded()
+
+        self.view1.snp_updateConstraints { make in
+            make.width.equalTo(self.superview).with.priority(999)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        XCTAssert(CGRectGetWidth(self.view1.frame) == CGRectGetWidth(self.superview.frame))
+        XCTAssert(self.view1.snp_installedLayoutConstraints.count == 2)
+    }
+
+    func testReplaceConstraintsFromConstantToRelation() {
+        self.view1.snp_makeConstraints { make in
+            make.width.equalTo(100)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        self.view1.snp_updateConstraints { make in
+            make.width.equalTo(self.view2).with.offset(50)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        XCTAssert(CGRectGetWidth(self.view1.frame) == CGRectGetWidth(self.view2.frame) + 50)
+        XCTAssert(self.view1.snp_installedLayoutConstraints.count == 1)
+    }
+
+    func testReplaceConstraintsFromRelationToConstant() {
+        self.view1.snp_makeConstraints { make in
+            make.width.equalTo(self.view2).with.offset(50)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        self.view1.snp_updateConstraints { make in
+            make.width.equalTo(100)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        XCTAssert(CGRectGetWidth(self.view1.frame) == 100)
+        XCTAssert(self.view1.snp_installedLayoutConstraints.count == 1)
+    }
+
+    func testReplaceConstraintsToAnotherRelation() {
+        self.view1.snp_makeConstraints { make in
+            make.width.equalTo(self.superview).with.offset(50)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        self.view1.snp_updateConstraints { make in
+            make.width.equalTo(self.view2).with.offset(25)
+            return
+        }
+        self.view1.layoutIfNeeded()
+
+        XCTAssert(CGRectGetWidth(self.view1.frame) == CGRectGetWidth(self.view2.frame) + 25)
+        XCTAssert(self.view1.snp_installedLayoutConstraints.count == 1)
+    }
+
+}


### PR DESCRIPTION
There are needs to replace existing constraints to another relationship.

For example:

![](http://s21.postimg.org/m7c5bss4n/cells.png)

<sup>[Image from Stack Overflow - "How to use auto-layout to move other views when a view is hidden?"](http://stackoverflow.com/questions/18065938/how-to-use-auto-layout-to-move-other-views-when-a-view-is-hidden)</sup>

We can make `UIView`'s width to 0, but it's not a good solution if there are lots of UI elements in the screen and have various cases.

In this case, the most expected code should be:

```swift
label1.snp_makeConstraints { make in
    make.left.equalTo(view.snp_right).with.offset(10)
}

label1.snp_updateConstraints { make in
    make.left.equalTo(10)
}
```


`updateConstraints()` currently provides updating **constant** only, so this code wouldn't be executed.

This PR makes `updateConstraints()` to replace existing constraints if needed. Some test codes are included.
