### PR TITLE
Fix for typo in OS check enabling iOS specific layout attributes

### DIFF
--- a/Snap/ConstraintAttributes.swift
+++ b/Snap/ConstraintAttributes.swift
@@ -124,7 +124,7 @@ internal struct ConstraintAttributes: RawOptionSetType, BooleanType {
             if (self & ConstraintAttributes.Baseline) {
                 attrs.append(.Baseline)
             }
-            #if os(ios)
+            #if os(iOS)
             if (self & ConstraintAttributes.FirstBaseline) {
                 attrs.append(.FirstBaseline)
             }


### PR DESCRIPTION
Fixes a typo that caused iOS-specific layout attributes not to be included installing a constraint. I discovered this when I noticed aligning to leading margin to a super view fell back to using the layout attribute of the first item of the constraint.