### PR TITLE
Workaround to fix Swift 1.2 regression

### DIFF
--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -411,7 +411,7 @@ public class Constraint {
             }
             
             // clean up the snp_installedLayoutConstraints
-            var layoutConstraints = view.snp_installedLayoutConstraints
+            var layoutConstraints = Array(view.snp_installedLayoutConstraints)
             var layoutConstraintsToKeep = Array<LayoutConstraint>()
             for layoutConstraint in layoutConstraints {
                 if !contains(layoutConstraintsToRemove, layoutConstraint) {

--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -402,10 +402,10 @@ public class Constraint {
         if let view = self.installedOnView {
             // remove all installed layout constraints
             var layoutConstraintsToRemove = Array<LayoutConstraint>()
-            if let installedLayoutConstraints = self.installedLayoutConstraints?.allObjects as? Array<LayoutConstraint> {
+            if let installedLayoutConstraints = self.installedLayoutConstraints?.allObjects.map({ $0 as! LayoutConstraint }) {
                 layoutConstraintsToRemove += installedLayoutConstraints
             }
-            
+
             if layoutConstraintsToRemove.count > 0 {
                 view.removeConstraints(layoutConstraintsToRemove)
             }

--- a/Snap/ConstraintMaker.swift
+++ b/Snap/ConstraintMaker.swift
@@ -70,7 +70,7 @@ public class ConstraintMaker {
         let maker = ConstraintMaker(view: view)
         block(make: maker)
         
-        var layoutConstraints = view.snp_installedLayoutConstraints
+        var layoutConstraints = Array(view.snp_installedLayoutConstraints)
         for constraint in maker.constraints {
             layoutConstraints += constraint.install()
         }
@@ -87,7 +87,7 @@ public class ConstraintMaker {
         let maker = ConstraintMaker(view: view)
         block(make: maker)
         
-        var layoutConstraints: Array<LayoutConstraint> = view.snp_installedLayoutConstraints
+        var layoutConstraints = Array(view.snp_installedLayoutConstraints)
         for existingLayoutConstraint in layoutConstraints {
             existingLayoutConstraint.constraint?.uninstall()
         }
@@ -109,7 +109,7 @@ public class ConstraintMaker {
         let maker = ConstraintMaker(view: view)
         block(make: maker)
         
-        var layoutConstraints = view.snp_installedLayoutConstraints
+        var layoutConstraints = Array(view.snp_installedLayoutConstraints)
         for constraint in maker.constraints {
             layoutConstraints += constraint.installOnView(updateExisting: true)
         }

--- a/Snap/View+Snap.swift
+++ b/Snap/View+Snap.swift
@@ -108,11 +108,8 @@ public extension View {
     
     internal var snp_installedLayoutConstraints: Array<LayoutConstraint> {
         get {
-            var constraints = objc_getAssociatedObject(self, &installedLayoutConstraintsKey) as? Array<LayoutConstraint>
-            if constraints != nil {
-                return constraints!
-            }
-            return []
+            let constraints = objc_getAssociatedObject(self, &installedLayoutConstraintsKey) as? [LayoutConstraint]
+            return constraints ?? []
         }
         set {
             objc_setAssociatedObject(self, &installedLayoutConstraintsKey, newValue, UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC))


### PR DESCRIPTION
Since we can't tell when this is going to be fixed in the language, It'd be great if Snap can workaround this issue in order to be able to use Snap on Swift 1.2.