### PR TITLE
Faster closest commonsuperview

### DIFF
--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -507,7 +507,7 @@ public class Constraint {
                     return view
                 }
                 views.insert(view)
-                fromView = view.superview
+                toView = view.superview
             }
         } while (fromView != nil || toView != nil)
 

--- a/Snap/Constraint.swift
+++ b/Snap/Constraint.swift
@@ -490,19 +490,28 @@ public class Constraint {
     }
     
     private class func closestCommonSuperviewFromView(fromView: View?, toView: View?) -> View? {
-        var closestCommonSuperview: View?
-        var secondViewSuperview: View? = toView
-        while closestCommonSuperview == nil && secondViewSuperview != nil {
-            var firstViewSuperview = fromView
-            while closestCommonSuperview == nil && firstViewSuperview != nil {
-                if secondViewSuperview == firstViewSuperview {
-                    closestCommonSuperview = secondViewSuperview
+        var views = Set<UIView>()
+        var fromView = fromView
+        var toView = toView
+        do {
+            if let view = fromView {
+                if views.contains(view) {
+                    return view
                 }
-                firstViewSuperview = firstViewSuperview?.superview
+                views.insert(view)
+                fromView = view.superview
             }
-            secondViewSuperview = secondViewSuperview?.superview
-        }
-        return closestCommonSuperview
+
+            if let view = toView {
+                if views.contains(view) {
+                    return view
+                }
+                views.insert(view)
+                fromView = view.superview
+            }
+        } while (fromView != nil || toView != nil)
+
+        return nil
     }
 }
 


### PR DESCRIPTION
The general idea is to move from an O(n^2) algorithm to a O(N) where N is the height of the view hierarchy tree. The algorithm is very simple: traverse the tree up starting from both views and keep the visited views in a set. When any of the nodes was already visited before: that must be the common superview.