### PR TITLE
No more calls to fatalError

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		2DBA080E1F1FAD66001CFED4 /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */; };
+		38D2255E213D37FA00C5FFD3 /* ConstraintMakerErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D2255C213D37BB00C5FFD3 /* ConstraintMakerErrorTests.swift */; };
+		38D22560213D381700C5FFD3 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D2255F213D381700C5FFD3 /* TestUtils.swift */; };
+		38D22562213D735200C5FFD3 /* ConstraintMakerErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D22561213D735200C5FFD3 /* ConstraintMakerErrorHandler.swift */; };
 		EE235F5F1C5785BC00C08960 /* Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F5E1C5785BC00C08960 /* Debugging.swift */; };
 		EE235F6D1C5785C600C08960 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F621C5785C600C08960 /* Constraint.swift */; };
 		EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F631C5785C600C08960 /* ConstraintDescription.swift */; };
@@ -48,6 +51,9 @@
 
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
+		38D2255C213D37BB00C5FFD3 /* ConstraintMakerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintMakerErrorTests.swift; sourceTree = "<group>"; };
+		38D2255F213D381700C5FFD3 /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
+		38D22561213D735200C5FFD3 /* ConstraintMakerErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintMakerErrorHandler.swift; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		EE235F5E1C5785BC00C08960 /* Debugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debugging.swift; sourceTree = "<group>"; };
 		EE235F621C5785C600C08960 /* Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraint.swift; sourceTree = "<group>"; };
@@ -159,6 +165,7 @@
 				EE235FA91C5785D400C08960 /* ConstraintMakerEditable.swift */,
 				EE235FAA1C5785D400C08960 /* ConstraintMakerRelatable.swift */,
 				EE235FAB1C5785D400C08960 /* ConstraintMakerExtendable.swift */,
+				38D22561213D735200C5FFD3 /* ConstraintMakerErrorHandler.swift */,
 			);
 			name = Maker;
 			sourceTree = "<group>";
@@ -235,7 +242,9 @@
 			isa = PBXGroup;
 			children = (
 				EECDB3691AC0C95C006BBC11 /* Info.plist */,
+				38D2255F213D381700C5FFD3 /* TestUtils.swift */,
 				EECDB36A1AC0C95C006BBC11 /* Tests.swift */,
+				38D2255C213D37BB00C5FFD3 /* ConstraintMakerErrorTests.swift */,
 			);
 			name = Tests;
 			path = ../Tests;
@@ -378,6 +387,7 @@
 				EE235F881C5785C600C08960 /* ConstraintItem.swift in Sources */,
 				2DBA080E1F1FAD66001CFED4 /* Typealiases.swift in Sources */,
 				EE235F9A1C5785CE00C08960 /* ConstraintPriorityTarget.swift in Sources */,
+				38D22560213D381700C5FFD3 /* TestUtils.swift in Sources */,
 				EEF68FC01D7865AA00980C26 /* ConstraintLayoutSupport.swift in Sources */,
 				EEF68FB01D784FB100980C26 /* ConstraintLayoutGuide+Extensions.swift in Sources */,
 				EE235F761C5785C600C08960 /* ConstraintConfig.swift in Sources */,
@@ -394,6 +404,7 @@
 				EE235F7F1C5785C600C08960 /* ConstraintRelation.swift in Sources */,
 				EEF68FB41D784FBA00980C26 /* UILayoutSupport+Extensions.swift in Sources */,
 				EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */,
+				38D22562213D735200C5FFD3 /* ConstraintMakerErrorHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -401,6 +412,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				38D2255E213D37FA00C5FFD3 /* ConstraintMakerErrorTests.swift in Sources */,
 				EECDB3931AC0CB52006BBC11 /* Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -70,7 +70,7 @@ public final class Constraint {
     
     // MARK: Initialization
 
-    internal init(from: ConstraintItem,
+    internal init?(from: ConstraintItem,
                   to: ConstraintItem,
                   relation: ConstraintRelation,
                   sourceLocation: (String, UInt),
@@ -114,7 +114,8 @@ public final class Constraint {
                         case .bottom:
                             layoutToAttribute = .bottomMargin
                         default:
-                            fatalError()
+                            assertionFailure("Internal error: unsupported margin layout attribute")
+                            return nil
                         }
                     } else if self.from.attributes == .margins && self.to.attributes == .edges {
                         switch layoutFromAttribute {
@@ -127,7 +128,8 @@ public final class Constraint {
                         case .bottomMargin:
                             layoutToAttribute = .bottom
                         default:
-                            fatalError()
+                            assertionFailure("Internal error: unsupported edge layout attribute")
+                            return nil
                         }
                     } else if self.from.attributes == self.to.attributes {
                         layoutToAttribute = layoutFromAttribute
@@ -244,13 +246,13 @@ public final class Constraint {
     public func updatePriorityRequired() -> Void {}
 
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityHigh() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityHigh() -> Void { assertionFailure("Must be implemented by Concrete subclass.") }
 
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityMedium() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityMedium() -> Void { assertionFailure("Must be implemented by Concrete subclass.") }
 
     @available(*, obsoleted:3.0, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityLow() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityLow() -> Void { assertionFailure("Must be implemented by Concrete subclass.") }
 
     // MARK: Internal
 
@@ -282,7 +284,8 @@ public final class Constraint {
             for layoutConstraint in layoutConstraints {
                 let existingLayoutConstraint = existingLayoutConstraints.first { $0 == layoutConstraint }
                 guard let updateLayoutConstraint = existingLayoutConstraint else {
-                    fatalError("Updated constraint could not find existing matching constraint to update: \(layoutConstraint)")
+                    assertionFailure("Updated constraint could not find existing matching constraint to update: \(layoutConstraint)")
+                    continue
                 }
 
                 let updateLayoutAttribute = (updateLayoutConstraint.secondAttribute == .notAnAttribute) ? updateLayoutConstraint.firstAttribute : updateLayoutConstraint.secondAttribute

--- a/Source/Constraint.swift
+++ b/Source/Constraint.swift
@@ -93,7 +93,7 @@ public final class Constraint {
         let layoutToAttributes = self.to.attributes.layoutAttributes
 
         // get layout from
-        let layoutFrom = self.from.layoutConstraintItem!
+        let layoutFrom = self.from.layoutConstraintItem
 
         // get relation
         let layoutRelation = self.relation.layoutRelation
@@ -269,10 +269,7 @@ public final class Constraint {
     }
 
     internal func activateIfNeeded(updatingExisting: Bool = false) {
-        guard let item = self.from.layoutConstraintItem else {
-            print("WARNING: SnapKit failed to get from item from constraint. Activate will be a no-op.")
-            return
-        }
+        let item = self.from.layoutConstraintItem
         let layoutConstraints = self.layoutConstraints
 
         if updatingExisting {
@@ -298,10 +295,7 @@ public final class Constraint {
     }
 
     internal func deactivateIfNeeded() {
-        guard let item = self.from.layoutConstraintItem else {
-            print("WARNING: SnapKit failed to get from item from constraint. Deactivate will be a no-op.")
-            return
-        }
+        let item = self.from.layoutConstraintItem
         let layoutConstraints = self.layoutConstraints
         NSLayoutConstraint.deactivate(layoutConstraints)
         item.remove(constraints: [self])

--- a/Source/ConstraintDescription.swift
+++ b/Source/ConstraintDescription.swift
@@ -39,6 +39,7 @@ public class ConstraintDescription {
     internal var multiplier: ConstraintMultiplierTarget = 1.0
     internal var constant: ConstraintConstantTarget = 0.0
     internal var priority: ConstraintPriorityTarget = 1000.0
+    internal var error: ConstraintMakerError? = nil
     internal lazy var constraint: Constraint? = {
         guard let relation = self.relation,
               let related = self.related,

--- a/Source/ConstraintItem.swift
+++ b/Source/ConstraintItem.swift
@@ -38,8 +38,9 @@ public final class ConstraintItem {
         self.attributes = attributes
     }
     
-    internal var layoutConstraintItem: LayoutConstraintItem? {
-        return self.target as? LayoutConstraintItem
+    internal var layoutConstraintItem: LayoutConstraintItem {
+        // Downcast to LayoutConstraintItem will always succeed
+        return self.target as! LayoutConstraintItem
     }
     
 }

--- a/Source/ConstraintMaker.swift
+++ b/Source/ConstraintMaker.swift
@@ -162,9 +162,15 @@ public class ConstraintMaker {
         closure(maker)
         var constraints: [Constraint] = []
         for description in maker.descriptions {
+            if let error = description.error {
+                ConstraintMakerErrorHandler.shared.errorHandler(error)
+                continue
+            }
+
             guard let constraint = description.constraint else {
                 continue
             }
+
             constraints.append(constraint)
         }
         return constraints

--- a/Source/ConstraintMakerErrorHandler.swift
+++ b/Source/ConstraintMakerErrorHandler.swift
@@ -21,34 +21,26 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(iOS) || os(tvOS)
-    import UIKit
-#else
-    import AppKit
-#endif
+public enum ConstraintMakerError: Error {
+    case invalidConstraint(file: String, line: UInt)
+    case missingSuperview(file: String, line: UInt)
+    case canNotConstraintToMultipleNonIdenticalAttributes(file: String, line: UInt)
 
+    var localizedDescription: String {
+        switch self {
+        case let .invalidConstraint(file, line): return "Invalid constraint. (\(file), \(line))"
+        case let .missingSuperview(file, line): return "Expected superview but found nil when attempting make constraint `equalToSuperview`. (\(file), \(line))"
+        case let .canNotConstraintToMultipleNonIdenticalAttributes(file, line): return "Cannot constraint to multiple non identical attributes. (\(file), \(line))"
+        }
+    }
+}
 
-public class ConstraintMakerFinalizable {
-    
-    internal let description: ConstraintDescription
-    
-    internal init(_ description: ConstraintDescription) {
-        self.description = description
-    }
+public class ConstraintMakerErrorHandler {
+    private init() {}
 
-    internal init(_ description: ConstraintDescription, error: ConstraintMakerError) {
-        self.description = description
-        description.error = error
+    public static let shared = ConstraintMakerErrorHandler()
+
+    public var errorHandler: ((Error) -> Void) = { (error: Error) in
+        fatalError(error.localizedDescription)
     }
-    
-    @discardableResult
-    public func labeled(_ label: String) -> ConstraintMakerFinalizable {
-        self.description.label = label
-        return self
-    }
-    
-    public var constraint: Constraint {
-        return self.description.constraint!
-    }
-    
 }

--- a/Source/ConstraintMakerErrorHandler.swift
+++ b/Source/ConstraintMakerErrorHandler.swift
@@ -41,6 +41,6 @@ public class ConstraintMakerErrorHandler {
     public static let shared = ConstraintMakerErrorHandler()
 
     public var errorHandler: ((Error) -> Void) = { (error: Error) in
-        fatalError(error.localizedDescription)
+        assertionFailure(error.localizedDescription)
     }
 }

--- a/Source/ConstraintMakerFinalizable.swift
+++ b/Source/ConstraintMakerFinalizable.swift
@@ -47,8 +47,8 @@ public class ConstraintMakerFinalizable {
         return self
     }
     
-    public var constraint: Constraint {
-        return self.description.constraint!
+    public var constraint: Constraint? {
+        return self.description.constraint
     }
     
 }

--- a/Source/ConstraintMakerRelatable.swift
+++ b/Source/ConstraintMakerRelatable.swift
@@ -27,7 +27,6 @@
     import AppKit
 #endif
 
-
 public class ConstraintMakerRelatable {
     
     internal let description: ConstraintDescription
@@ -46,7 +45,7 @@ public class ConstraintMakerRelatable {
                   other.attributes.layoutAttributes == self.description.attributes.layoutAttributes ||
                   other.attributes == .edges && self.description.attributes == .margins ||
                   other.attributes == .margins && self.description.attributes == .edges else {
-                fatalError("Cannot constraint to multiple non identical attributes. (\(file), \(line))");
+                return ConstraintMakerEditable(self.description, error: ConstraintMakerError.canNotConstraintToMultipleNonIdenticalAttributes(file: file, line: line))
             }
             
             related = other
@@ -61,7 +60,7 @@ public class ConstraintMakerRelatable {
             related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
             constant = 0.0
         } else {
-            fatalError("Invalid constraint. (\(file), \(line))")
+            return ConstraintMakerEditable(self.description, error: ConstraintMakerError.invalidConstraint(file: file, line: line))
         }
         
         let editable = ConstraintMakerEditable(self.description)
@@ -80,7 +79,7 @@ public class ConstraintMakerRelatable {
     @discardableResult
     public func equalToSuperview(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
-            fatalError("Expected superview but found nil when attempting make constraint `equalToSuperview`.")
+            return ConstraintMakerEditable(self.description, error: ConstraintMakerError.missingSuperview(file: file, line: line))
         }
         return self.relatedTo(other, relation: .equal, file: file, line: line)
     }
@@ -93,7 +92,7 @@ public class ConstraintMakerRelatable {
     @discardableResult
     public func lessThanOrEqualToSuperview(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
-            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperview`.")
+            return ConstraintMakerEditable(self.description, error: ConstraintMakerError.missingSuperview(file: file, line: line))
         }
         return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
     }
@@ -106,7 +105,7 @@ public class ConstraintMakerRelatable {
     @discardableResult
     public func greaterThanOrEqualToSuperview(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
-            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
+            return ConstraintMakerEditable(self.description, error: ConstraintMakerError.missingSuperview(file: file, line: line))
         }
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -1,24 +1,25 @@
-#if os(iOS) || os(tvOS)
-import UIKit
-typealias View = UIView
-extension View {
-    var snp_constraints: [AnyObject] {
-        return self.constraints
-            .filter { $0 is LayoutConstraint }
-            .filter { $0.isActive }
-    }
-}
-#else
-import AppKit
-typealias View = NSView
-extension View {
-    var snp_constraints: [AnyObject] {
-        return self.constraints
-            .filter { $0 is LayoutConstraint }
-            .filter { $0.isActive }
-    }
-}
-#endif
+//
+//  SnapKit
+//
+//  Copyright (c) 2011-Present SnapKit Team - https://github.com/SnapKit
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 
 import XCTest
 @testable import SnapKit

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -22,33 +22,23 @@
 //  THE SOFTWARE.
 
 #if os(iOS) || os(tvOS)
-    import UIKit
-#else
-    import AppKit
-#endif
-
-
-public class ConstraintMakerFinalizable {
-    
-    internal let description: ConstraintDescription
-    
-    internal init(_ description: ConstraintDescription) {
-        self.description = description
+import UIKit
+typealias View = UIView
+extension View {
+    var snp_constraints: [AnyObject] {
+        return self.constraints
+            .filter { $0 is LayoutConstraint }
+            .filter { $0.isActive }
     }
-
-    internal init(_ description: ConstraintDescription, error: ConstraintMakerError) {
-        self.description = description
-        description.error = error
-    }
-    
-    @discardableResult
-    public func labeled(_ label: String) -> ConstraintMakerFinalizable {
-        self.description.label = label
-        return self
-    }
-    
-    public var constraint: Constraint {
-        return self.description.constraint!
-    }
-    
 }
+#else
+import AppKit
+typealias View = NSView
+extension View {
+    var snp_constraints: [AnyObject] {
+        return self.constraints
+            .filter { $0 is LayoutConstraint }
+            .filter { $0.isActive }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #537 

In this change

- The constraint maker no longer calls `fatalError` but emits a `ConstraintMakerEditable` with an error inside
- The `prepareConstraints(item:closure:)` method checks for errors and calls the `ConstraintMakerErrorHandler`
- The `ConstraintMakerErrorHandler` calls to `assertionFailure` instead of `fatalError` to prevent production crashers. Its behaviour can be globally overridden
- All calls to `fatalError` have been changed to call `assertionFailure`
- An unneeded force unwrap has been resolved
- Make `layoutConstraintItem` non optional because its optionality is not needed and not handled well

