### PR TITLE
Open up Target protocols

### DIFF
--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3CA7D6C224592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA7D6C124592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift */; };
 		7E1CB2AE227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */; };
 		7E1CB2B0227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E1CB2AF227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift */; };
+		37AC176121B76CE700974541 /* RawRepresentable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AC176021B76CE700974541 /* RawRepresentable+Extensions.swift */; };
 		EE235F5F1C5785BC00C08960 /* Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F5E1C5785BC00C08960 /* Debugging.swift */; };
 		EE235F6D1C5785C600C08960 /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F621C5785C600C08960 /* Constraint.swift */; };
 		EE235F701C5785C600C08960 /* ConstraintDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE235F631C5785C600C08960 /* ConstraintDescription.swift */; };
@@ -51,6 +52,7 @@
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
 		3CA7D6C124592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConstraintMakerRelatable+Extensions.swift"; sourceTree = "<group>"; };
+		37AC176021B76CE700974541 /* RawRepresentable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RawRepresentable+Extensions.swift"; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		7E1CB2AD227BB5520066B6C0 /* ConstraintDirectionalInsetTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintDirectionalInsetTarget.swift; sourceTree = "<group>"; };
 		7E1CB2AF227BBDF70066B6C0 /* ConstraintDirectionalInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintDirectionalInsets.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 			children = (
 				EE235FC61C5785E200C08960 /* ConstraintView+Extensions.swift */,
 				EEF68FAF1D784FB100980C26 /* ConstraintLayoutGuide+Extensions.swift */,
+				37AC176021B76CE700974541 /* RawRepresentable+Extensions.swift */,
 				EEF68FB31D784FBA00980C26 /* UILayoutSupport+Extensions.swift */,
 				3CA7D6C124592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift */,
 			);
@@ -384,6 +387,7 @@
 				EE235F881C5785C600C08960 /* ConstraintItem.swift in Sources */,
 				2DBA080E1F1FAD66001CFED4 /* Typealiases.swift in Sources */,
 				EE235F9A1C5785CE00C08960 /* ConstraintPriorityTarget.swift in Sources */,
+				37AC176121B76CE700974541 /* RawRepresentable+Extensions.swift in Sources */,
 				EEF68FC01D7865AA00980C26 /* ConstraintLayoutSupport.swift in Sources */,
 				EEF68FB01D784FB100980C26 /* ConstraintLayoutGuide+Extensions.swift in Sources */,
 				EE235F761C5785C600C08960 /* ConstraintConfig.swift in Sources */,

--- a/Sources/ConstraintConstantTarget.swift
+++ b/Sources/ConstraintConstantTarget.swift
@@ -29,6 +29,9 @@
 
 
 public protocol ConstraintConstantTarget {
+
+    func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat
+
 }
 
 extension CGPoint: ConstraintConstantTarget {
@@ -48,7 +51,7 @@ extension ConstraintDirectionalInsets: ConstraintConstantTarget {
 
 extension ConstraintConstantTarget {
     
-    internal func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
+    public func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
         if let value = self as? CGFloat {
             return value
         }

--- a/Sources/ConstraintInsetTarget.swift
+++ b/Sources/ConstraintInsetTarget.swift
@@ -29,6 +29,9 @@
 
 
 public protocol ConstraintInsetTarget: ConstraintConstantTarget {
+
+    var constraintInsetTargetValue: ConstraintInsets { get }
+
 }
 
 extension Int: ConstraintInsetTarget {
@@ -51,7 +54,7 @@ extension ConstraintInsets: ConstraintInsetTarget {
 
 extension ConstraintInsetTarget {
 
-    internal var constraintInsetTargetValue: ConstraintInsets {
+    public var constraintInsetTargetValue: ConstraintInsets {
         if let amount = self as? ConstraintInsets {
             return amount
         } else if let amount = self as? Float {

--- a/Sources/RawRepresentable+Extensions.swift
+++ b/Sources/RawRepresentable+Extensions.swift
@@ -28,45 +28,34 @@
 #endif
 
 
-public protocol ConstraintOffsetTarget: ConstraintConstantTarget {
+public extension RawRepresentable where Self: ConstraintConstantTarget, Self.RawValue: ConstraintConstantTarget {
 
-    var constraintOffsetTargetValue: CGFloat { get }
-
-}
-
-extension Int: ConstraintOffsetTarget {
-}
-
-extension UInt: ConstraintOffsetTarget {
-}
-
-extension Float: ConstraintOffsetTarget {
-}
-
-extension Double: ConstraintOffsetTarget {
-}
-
-extension CGFloat: ConstraintOffsetTarget {
-}
-
-extension ConstraintOffsetTarget {
-    
-    public var constraintOffsetTargetValue: CGFloat {
-        let offset: CGFloat
-        if let amount = self as? Float {
-            offset = CGFloat(amount)
-        } else if let amount = self as? Double {
-            offset = CGFloat(amount)
-        } else if let amount = self as? CGFloat {
-            offset = CGFloat(amount)
-        } else if let amount = self as? Int {
-            offset = CGFloat(amount)
-        } else if let amount = self as? UInt {
-            offset = CGFloat(amount)
-        } else {
-            offset = 0.0
-        }
-        return offset
+    public func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
+        return rawValue.constraintConstantTargetValueFor(layoutAttribute: layoutAttribute)
     }
-    
+
+}
+
+public extension RawRepresentable where Self: ConstraintMultiplierTarget, Self.RawValue: ConstraintMultiplierTarget {
+
+    public var constraintMultiplierTargetValue: CGFloat {
+        return rawValue.constraintMultiplierTargetValue
+    }
+
+}
+
+public extension RawRepresentable where Self: ConstraintOffsetTarget, Self.RawValue: ConstraintOffsetTarget {
+
+    public var constraintOffsetTargetValue: CGFloat {
+        return rawValue.constraintOffsetTargetValue
+    }
+
+}
+
+public extension RawRepresentable where Self: ConstraintInsetTarget, Self.RawValue: ConstraintInsetTarget {
+
+    public var constraintInsetTargetValue: ConstraintInsets {
+        return rawValue.constraintInsetTargetValue
+    }
+
 }

--- a/Sources/Typealiases.swift
+++ b/Sources/Typealiases.swift
@@ -27,16 +27,16 @@ import Foundation
     import UIKit
 #if swift(>=4.2)
     typealias LayoutRelation = NSLayoutConstraint.Relation
-    typealias LayoutAttribute = NSLayoutConstraint.Attribute
+    public typealias LayoutAttribute = NSLayoutConstraint.Attribute
 #else
     typealias LayoutRelation = NSLayoutRelation
-    typealias LayoutAttribute = NSLayoutAttribute
+    public typealias LayoutAttribute = NSLayoutAttribute
 #endif
     typealias LayoutPriority = UILayoutPriority
 #else
     import AppKit
     typealias LayoutRelation = NSLayoutConstraint.Relation
-    typealias LayoutAttribute = NSLayoutConstraint.Attribute
+    public typealias LayoutAttribute = NSLayoutConstraint.Attribute
     typealias LayoutPriority = NSLayoutConstraint.Priority
 #endif
 

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -768,4 +768,29 @@ class SnapKitTests: XCTestCase {
         let higherPriority: ConstraintPriority = ConstraintPriority.high.advanced(by: 1)
         XCTAssertEqual(higherPriority.value, highPriority.value + 1)
     }
+
+    func testEnumAsConstraints() {
+        let view = View()
+        self.container.addSubview(view)
+
+        view.snp.makeConstraints { make in
+            make.top.equalTo(Enum.value)
+            make.height.equalToSuperview().multipliedBy(Enum.value)
+            make.left.equalToSuperview().offset(Enum.value)
+            make.right.equalToSuperview().inset(Enum.value)
+        }
+
+        XCTAssertEqual(self.container.snp_constraints.count, 4, "Should have 4 constraints")
+
+        let constraints = (self.container.snp_constraints as! [NSLayoutConstraint]).sorted { $0.constant > $1.constant }
+
+        XCTAssertEqual(constraints[0].constant, Enum.value.rawValue, "Should be enum")
+        XCTAssertEqual(constraints[1].constant, Enum.value.rawValue, "Should be enum")
+        XCTAssertEqual(constraints[2].multiplier, Enum.value.rawValue, "Multiplier should be enum")
+        XCTAssertEqual(constraints[3].constant, -Enum.value.rawValue, "Should be negative enum")
+    }
+}
+
+private enum Enum: CGFloat, ConstraintRelatableTarget, ConstraintMultiplierTarget, ConstraintOffsetTarget, ConstraintInsetTarget {
+    case value = 50
 }


### PR DESCRIPTION
This PR updates the protocol requirements for `ConstraintConstantTarget`, `ConstraintOffsetTarget`, and `ConstraintInsetTarget` to be public (just like `ConstraintMultiplierTarget`), allowing for conformance by custom types:
```swift
enum Margin: Int, ConstraintOffsetTarget {
    case small = 10
    case large = 20
}

...

make.left.equalToSuperview().offset(Margin.small)
```
I also included some `RawRepresentable` extensions, so that opting-in can be as easy as putting it in the type declaration. If that's out of scope, these can be omitted, leaving implementations to the user.