### PR TITLE
Convenient to add width height ratio constraints

### DIFF
--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -31,6 +31,24 @@
 extension ConstraintMakerRelatable {
   
     @discardableResult
+    public func equalToSelf(_ keyPath: KeyPath<ConstraintViewDSL, ConstraintItem>, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        guard let view = self.description.item.view else {
+            fatalError("Expected view but found nil when attempting make constraint `equalToSelf`.")
+        }
+        return equalTo(view.snp[keyPath: keyPath], file, line)
+    }
+    
+    @discardableResult
+    public func equalToSelfWidth(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return equalToSelf(\.width, file, line)
+    }
+    
+    @discardableResult
+    public func equalToSelfHeight(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        return equalToSelf(\.height, file, line)
+    }
+    
+    @discardableResult
     public func equalToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `equalToSuperview`.")

--- a/Sources/LayoutConstraintItem.swift
+++ b/Sources/LayoutConstraintItem.swift
@@ -47,6 +47,13 @@ extension LayoutConstraintItem {
         }
     }
     
+    internal var view: ConstraintView? {
+        if let view = self as? ConstraintView {
+            return view
+        }
+        return nil
+    }
+    
     internal var superview: ConstraintView? {
         if let view = self as? ConstraintView {
             return view.superview


### PR DESCRIPTION
Convenient to add width height ratio constraints

Before

```Swift
UILabel().do { label in
  label.backgroundColor = .darkGray
  view.addSubview(label)
  label.snp.makeConstraints { make in
    make.width.equalTo(100)
    make.height.equalTo(label.snp.width).multipliedBy(0.5)
    make.center.equalToSuperview() 
  }
}
```

After

```Swift
UILabel().do {
  $0.backgroundColor = .darkGray
  view.addSubview($0)
  $0.snp.makeConstraints { make in
    make.width.equalTo(100)
    make.height.equalToSelf(\.width).multipliedBy(0.5)
    make.center.equalToSuperview()
  }
}
```

