### PR TITLE
OSX -> macOS in ReadMe & Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://snapkit.github.io/SnapKit/images/banner.jpg" alt="" />
 
-SnapKit is a DSL to make Auto Layout easy on both iOS and OS X.
+SnapKit is a DSL to make Auto Layout easy on both iOS and macOS.
 
 [![Build Status](https://travis-ci.org/SnapKit/SnapKit.svg)](https://travis-ci.org/SnapKit/SnapKit)
 [![Platform](https://img.shields.io/cocoapods/p/SnapKit.svg?style=flat)](https://github.com/SnapKit/SnapKit)
@@ -22,7 +22,7 @@ SnapKit is a DSL to make Auto Layout easy on both iOS and OS X.
 
 ## Requirements
 
-- iOS 10.0+ / Mac OS X 10.12+ / tvOS 10.0+
+- iOS 10.0+ / macOS 10.12+ / tvOS 10.0+
 - Xcode 10.0+
 - Swift 4.0+
 

--- a/Sources/ConstraintAttributes.swift
+++ b/Sources/ConstraintAttributes.swift
@@ -69,7 +69,7 @@ internal struct ConstraintAttributes : OptionSet, ExpressibleByIntegerLiteral {
     internal static let centerY: ConstraintAttributes = ConstraintAttributes(UInt(1) << 9)
     internal static let lastBaseline: ConstraintAttributes = ConstraintAttributes(UInt(1) << 10)
     
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     internal static let firstBaseline: ConstraintAttributes = ConstraintAttributes(UInt(1) << 11)
 
     @available(iOS 8.0, *)

--- a/Sources/ConstraintDSL.swift
+++ b/Sources/ConstraintDSL.swift
@@ -139,12 +139,12 @@ extension ConstraintAttributesDSL {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
     }
     
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     public var lastBaseline: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
     }
     
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     public var firstBaseline: ConstraintItem {
         return ConstraintItem(target: self.target, attributes: ConstraintAttributes.firstBaseline)
     }

--- a/Sources/ConstraintLayoutGuide+Extensions.swift
+++ b/Sources/ConstraintLayoutGuide+Extensions.swift
@@ -26,7 +26,7 @@
 #endif
     
     
-@available(iOS 9.0, OSX 10.11, *)
+@available(iOS 9.0, macOS 10.11, *)
 public extension ConstraintLayoutGuide {
     
     var snp: ConstraintLayoutGuideDSL {

--- a/Sources/ConstraintLayoutGuide.swift
+++ b/Sources/ConstraintLayoutGuide.swift
@@ -32,6 +32,6 @@
     @available(iOS 9.0, *)
     public typealias ConstraintLayoutGuide = UILayoutGuide
 #else
-    @available(OSX 10.11, *)
+    @available(macOS 10.11, *)
     public typealias ConstraintLayoutGuide = NSLayoutGuide
 #endif

--- a/Sources/ConstraintLayoutGuideDSL.swift
+++ b/Sources/ConstraintLayoutGuideDSL.swift
@@ -28,7 +28,7 @@
 #endif
 
 
-@available(iOS 9.0, OSX 10.11, *)
+@available(iOS 9.0, macOS 10.11, *)
 public struct ConstraintLayoutGuideDSL: ConstraintAttributesDSL {
     
     @discardableResult

--- a/Sources/ConstraintMaker.swift
+++ b/Sources/ConstraintMaker.swift
@@ -78,7 +78,7 @@ public class ConstraintMaker {
         return self.makeExtendableWithAttributes(.lastBaseline)
     }
     
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     public var firstBaseline: ConstraintMakerExtendable {
         return self.makeExtendableWithAttributes(.firstBaseline)
     }

--- a/Sources/ConstraintMakerExtendable.swift
+++ b/Sources/ConstraintMakerExtendable.swift
@@ -91,7 +91,7 @@ public class ConstraintMakerExtendable: ConstraintMakerRelatable {
         return self
     }
     
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     public var firstBaseline: ConstraintMakerExtendable {
         self.description.attributes += .firstBaseline
         return self

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -59,7 +59,7 @@ public class ConstraintMakerRelatable {
         } else if let other = other as? ConstraintConstantTarget {
             related = ConstraintItem(target: nil, attributes: ConstraintAttributes.none)
             constant = other
-        } else if #available(iOS 9.0, OSX 10.11, *), let other = other as? ConstraintLayoutGuide {
+        } else if #available(iOS 9.0, macOS 10.11, *), let other = other as? ConstraintLayoutGuide {
             related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
             constant = 0.0
         } else {

--- a/Sources/ConstraintPriority.swift
+++ b/Sources/ConstraintPriority.swift
@@ -49,7 +49,7 @@ public struct ConstraintPriority : ExpressibleByFloatLiteral, Equatable, Stridea
     }
     
     public static var medium: ConstraintPriority {
-        #if os(OSX)
+        #if os(macOS)
             return 501.0
         #else
             return 500.0

--- a/Sources/ConstraintRelatableTarget.swift
+++ b/Sources/ConstraintRelatableTarget.swift
@@ -67,6 +67,6 @@ extension ConstraintItem: ConstraintRelatableTarget {
 extension ConstraintView: ConstraintRelatableTarget {
 }
 
-@available(iOS 9.0, OSX 10.11, *)
+@available(iOS 9.0, macOS 10.11, *)
 extension ConstraintLayoutGuide: ConstraintRelatableTarget {
 }

--- a/Sources/ConstraintView+Extensions.swift
+++ b/Sources/ConstraintView+Extensions.swift
@@ -64,11 +64,11 @@ public extension ConstraintView {
     var snp_baseline: ConstraintItem { return self.snp.baseline }
     
     @available(*, deprecated, renamed:"snp.lastBaseline")
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     var snp_lastBaseline: ConstraintItem { return self.snp.lastBaseline }
     
     @available(iOS, deprecated, renamed:"snp.firstBaseline")
-    @available(iOS 8.0, OSX 10.11, *)
+    @available(iOS 8.0, macOS 10.11, *)
     var snp_firstBaseline: ConstraintItem { return self.snp.firstBaseline }
     
     @available(iOS, deprecated, renamed:"snp.leftMargin")

--- a/Sources/LayoutConstraintItem.swift
+++ b/Sources/LayoutConstraintItem.swift
@@ -31,7 +31,7 @@
 public protocol LayoutConstraintItem: AnyObject {
 }
 
-@available(iOS 9.0, OSX 10.11, *)
+@available(iOS 9.0, macOS 10.11, *)
 extension ConstraintLayoutGuide : LayoutConstraintItem {
 }
 
@@ -52,7 +52,7 @@ extension LayoutConstraintItem {
             return view.superview
         }
         
-        if #available(iOS 9.0, OSX 10.11, *), let guide = self as? ConstraintLayoutGuide {
+        if #available(iOS 9.0, macOS 10.11, *), let guide = self as? ConstraintLayoutGuide {
             return guide.owningView
         }
         

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -101,7 +101,7 @@ class SnapKitTests: XCTestCase {
     }
     
     func testGuideMakeConstraints() {
-        guard #available(iOS 9.0, OSX 10.11, *) else { return }
+        guard #available(iOS 9.0, macOS 10.11, *) else { return }
         let v1 = View()
 
         let g1 = ConstraintLayoutGuide()


### PR DESCRIPTION
On June 13, 2016, at WWDC16, OS X was renamed macOS.
But here in the gitignore file this hasn't changed.
Plz merge it.

[And what you need to do]
- Change the text that says OSX in the banner image
