### PR TITLE
fix for Xcode 14 : iOS 12 crash dyld: Library not loaded: /usr/lib/swift/libswiftCoreGraphics.dylib Reason: image not found

### DIFF
--- a/SnapKit.podspec
+++ b/SnapKit.podspec
@@ -14,5 +14,11 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/*.swift'
 
+  s.libraries = 'swiftCoreGraphics'
+
+  s.xcconfig = {
+      'LIBRARY_SEARCH_PATHS' => '$(SDKROOT)/usr/lib/swift',
+  }
+
   s.swift_versions = ['5.0']
 end


### PR DESCRIPTION
fix for Xcode 14 : iOS 12 crash 
dyld: Library not loaded: /usr/lib/swift/libswiftCoreGraphics.dylib
Reason: image not found