### PR TITLE
Removed the `line` argument labels

### DIFF
--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -27,9 +27,8 @@
     import AppKit
 #endif
 
-
 extension ConstraintMakerRelatable {
-  
+    
     @discardableResult
     public func equalToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
@@ -37,7 +36,7 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .equal, file: file, line: line)
     }
-  
+    
     @discardableResult
     public func lessThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
@@ -45,7 +44,7 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .lessThanOrEqual, file: file, line: line)
     }
-  
+    
     @discardableResult
     public func greaterThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
@@ -53,5 +52,31 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
     }
-  
+    
+    @available(*, deprecated, renamed: "equalToSuperview(_:_:)", message: "Removed the `line` argument label")
+    @discardableResult
+    public func equalToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `equalToSuperview`.")
+        }
+        return self.relatedTo(closure(other), relation: .equal, file: file, line: line)
+    }
+    
+    @available(*, deprecated, renamed: "lessThanOrEqualToSuperview(_:_:)", message: "Removed the `line` argument label")
+    @discardableResult
+    public func lessThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(closure(other), relation: .lessThanOrEqual, file: file, line: line)
+    }
+    
+    @available(*, deprecated, renamed: "greaterThanOrEqualToSuperview(_:_:)", message: "Removed the `line` argument label")
+    @discardableResult
+    public func greaterThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
+    }
 }

--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -31,7 +31,7 @@
 extension ConstraintMakerRelatable {
   
     @discardableResult
-    public func equalToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+    public func equalToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `equalToSuperview`.")
         }
@@ -39,7 +39,7 @@ extension ConstraintMakerRelatable {
     }
   
     @discardableResult
-    public func lessThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+    public func lessThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperview`.")
         }
@@ -47,7 +47,7 @@ extension ConstraintMakerRelatable {
     }
   
     @discardableResult
-    public func greaterThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+    public func greaterThanOrEqualToSuperview<T: ConstraintRelatableTarget>(_ closure: (ConstraintView) -> T, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
         }

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -101,12 +101,12 @@ public class ConstraintMakerRelatable {
     }
     
     @discardableResult
-    public func greaterThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+    public func greaterThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }
     
     @discardableResult
-    public func greaterThanOrEqualToSuperview(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+    public func greaterThanOrEqualToSuperview(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
         }

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -112,4 +112,19 @@ public class ConstraintMakerRelatable {
         }
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }
+    
+    @available(*, deprecated, renamed: "greaterThanOrEqualTo(_:_:_:)", message: "Removed the `line` argument label")
+    @discardableResult
+    public func greaterThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
+    }
+    
+    @available(*, deprecated, renamed: "greaterThanOrEqualToSuperview(_:_:)", message: "Removed the `line` argument label")
+    @discardableResult
+    public func greaterThanOrEqualToSuperview(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview else {
+            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
+    }
 }


### PR DESCRIPTION
In the `ConstraintMakerRelatable` class, some methods have not `line` argument label, and some methods have. I remove all the `line` argument labels, to make them have the same style.