### PR TITLE
equalToSuperviewSafeAreaLayoutGuide, lessThanOrEqualToSuperviewSafeAreaLayoutGuide and greaterThanOrEqualToSuperviewSafeAreaLayoutGuide

### DIFF
--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -53,5 +53,31 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
     }
-  
+
+    @available(iOS 11.0, *)
+    @discardableResult
+    public func equalToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `equalToSuperviewSafeAreaLayoutGuide`.")
+        }
+        return self.relatedTo(closure(other), relation: .equal, file: file, line: line)
+    }
+
+    @available(iOS 11.0, *)
+    @discardableResult
+    public func lessThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
+        }
+        return self.relatedTo(closure(other), relation: .lessThanOrEqual, file: file, line: line)
+    }
+
+    @available(iOS 11.0, *)
+    @discardableResult
+    public func greaterThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
+        }
+        return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
+    }
 }

--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -54,7 +54,7 @@ extension ConstraintMakerRelatable {
         return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
     }
 
-    @available(iOS 11.0, *)
+    @available(iOS 11.0, macOS 11.0, *)
     @discardableResult
     public func equalToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
@@ -63,7 +63,7 @@ extension ConstraintMakerRelatable {
         return self.relatedTo(closure(other), relation: .equal, file: file, line: line)
     }
 
-    @available(iOS 11.0, *)
+    @available(iOS 11.0, macOS 11.0, *)
     @discardableResult
     public func lessThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
@@ -72,7 +72,7 @@ extension ConstraintMakerRelatable {
         return self.relatedTo(closure(other), relation: .lessThanOrEqual, file: file, line: line)
     }
 
-    @available(iOS 11.0, *)
+    @available(iOS 11.0, macOS 11.0, *)
     @discardableResult
     public func greaterThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {

--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -53,4 +53,5 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
     }
+  
 }

--- a/Sources/ConstraintMakerRelatable+Extensions.swift
+++ b/Sources/ConstraintMakerRelatable+Extensions.swift
@@ -53,31 +53,4 @@ extension ConstraintMakerRelatable {
         }
         return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
     }
-
-    @available(iOS 11.0, macOS 11.0, *)
-    @discardableResult
-    public func equalToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
-        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
-            fatalError("Expected superview but found nil when attempting make constraint `equalToSuperviewSafeAreaLayoutGuide`.")
-        }
-        return self.relatedTo(closure(other), relation: .equal, file: file, line: line)
-    }
-
-    @available(iOS 11.0, macOS 11.0, *)
-    @discardableResult
-    public func lessThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
-        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
-            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
-        }
-        return self.relatedTo(closure(other), relation: .lessThanOrEqual, file: file, line: line)
-    }
-
-    @available(iOS 11.0, macOS 11.0, *)
-    @discardableResult
-    public func greaterThanOrEqualToSuperviewSafeAreaLayoutGuide<T: ConstraintRelatableTarget>(_ closure: (ConstraintLayoutGuide) -> T, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
-        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
-            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
-        }
-        return self.relatedTo(closure(other), relation: .greaterThanOrEqual, file: file, line: line)
-    }
 }

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -87,7 +87,7 @@ public class ConstraintMakerRelatable {
         return self.relatedTo(other, relation: .equal, file: file, line: line)
     }
 
-    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @available(iOS 11.0, tvOS 11.0, macOS 11.0, *)
     @discardableResult
     public func equalToSuperviewSafeAreaLayoutGuide(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
@@ -109,7 +109,7 @@ public class ConstraintMakerRelatable {
         return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
     }
 
-    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @available(iOS 11.0, tvOS 11.0, macOS 11.0, *)
     @discardableResult
     public func lessThanOrEqualToSuperviewSafeAreaLayoutGuide(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
@@ -131,7 +131,7 @@ public class ConstraintMakerRelatable {
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }
 
-    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @available(iOS 11.0, tvOS 11.0, macOS 11.0, *)
     @discardableResult
     public func greaterThanOrEqualToSuperviewSafeAreaLayoutGuide(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview?.safeAreaLayoutGuide else {

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -86,7 +86,16 @@ public class ConstraintMakerRelatable {
         }
         return self.relatedTo(other, relation: .equal, file: file, line: line)
     }
-    
+
+    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @discardableResult
+    public func equalToSuperviewSafeAreaLayoutGuide(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `equalToSuperviewSafeAreaLayoutGuide`.")
+        }
+        return self.relatedTo(other, relation: .equal, file: file, line: line)
+    }
+
     @discardableResult
     public func lessThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
         return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
@@ -99,7 +108,16 @@ public class ConstraintMakerRelatable {
         }
         return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
     }
-    
+
+    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @discardableResult
+    public func lessThanOrEqualToSuperviewSafeAreaLayoutGuide(_ file: String = #file, _ line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `lessThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
+        }
+        return self.relatedTo(other, relation: .lessThanOrEqual, file: file, line: line)
+    }
+
     @discardableResult
     public func greaterThanOrEqualTo(_ other: ConstraintRelatableTarget, _ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
@@ -109,6 +127,15 @@ public class ConstraintMakerRelatable {
     public func greaterThanOrEqualToSuperview(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
         guard let other = self.description.item.superview else {
             fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperview`.")
+        }
+        return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
+    }
+
+    @available(iOS 11.0, tvOS 11.0, macOS 11.00, *)
+    @discardableResult
+    public func greaterThanOrEqualToSuperviewSafeAreaLayoutGuide(_ file: String = #file, line: UInt = #line) -> ConstraintMakerEditable {
+        guard let other = self.description.item.superview?.safeAreaLayoutGuide else {
+            fatalError("Expected superview but found nil when attempting make constraint `greaterThanOrEqualToSuperviewSafeAreaLayoutGuide`.")
         }
         return self.relatedTo(other, relation: .greaterThanOrEqual, file: file, line: line)
     }

--- a/Tests/SnapKitTests/Tests.swift
+++ b/Tests/SnapKitTests/Tests.swift
@@ -768,4 +768,38 @@ class SnapKitTests: XCTestCase {
         let higherPriority: ConstraintPriority = ConstraintPriority.high.advanced(by: 1)
         XCTAssertEqual(higherPriority.value, highPriority.value + 1)
     }
+
+    @available(iOS 11.0, tvOS 11.0, macOS 11.0, *)
+    func testSafeAreaLayoutGuide() {
+        let v1 = View()
+        self.container.addSubview(v1)
+
+        v1.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperviewSafeAreaLayoutGuide()
+            make.leading.lessThanOrEqualToSuperviewSafeAreaLayoutGuide()
+            make.trailing.greaterThanOrEqualToSuperviewSafeAreaLayoutGuide()
+        }
+
+        XCTAssertEqual(container.snp_constraints.count, 4, "Should have 4 constraints installed")
+        XCTAssertNotNil(container.constraints.first {
+            $0.firstAttribute == .leading &&
+            $0.secondAttribute == .leading &&
+            $0.relation == .lessThanOrEqual
+        })
+        XCTAssertNotNil(container.constraints.first {
+            $0.firstAttribute == .trailing &&
+            $0.secondAttribute == .trailing &&
+            $0.relation == .greaterThanOrEqual
+        })
+        XCTAssertNotNil(container.constraints.first {
+            $0.firstAttribute == .top &&
+            $0.secondAttribute == .top &&
+            $0.relation == .equal
+        })
+        XCTAssertNotNil(container.constraints.first {
+            $0.firstAttribute == .bottom &&
+            $0.secondAttribute == .bottom &&
+            $0.relation == .equal
+        })
+    }
 }


### PR DESCRIPTION
Hello.
Thank you for SnapKit.
You already have `equalToSuperview`, `lessThanOrEqualToSuperview` and `greaterThanOrEqualToSuperview`. But what about similar methods for `superview?.safeAreaLayoutGuide`?