### PR TITLE
Add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 //
 //  SnapKit
 //
@@ -37,7 +37,9 @@ let package = Package(
         .library(name: "SnapKit-Dynamic", type: .dynamic, targets: ["SnapKit"]),
     ],
     targets: [
-        .target(name: "SnapKit", path: "Sources"),
+        .target(name: "SnapKit", 
+                path: "Sources",
+                resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(name: "SnapKitTests", dependencies: ["SnapKit"]),
     ],
     swiftLanguageVersions: [

--- a/SnapKit.podspec
+++ b/SnapKit.podspec
@@ -21,4 +21,5 @@ Pod::Spec.new do |s|
   }
 
   s.swift_versions = ['5.0']
+  s.resource_bundles = {"SnapKit" => ["Sources/PrivacyInfo.xcprivacy"]}
 end

--- a/SnapKit.xcodeproj/project.pbxproj
+++ b/SnapKit.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 
 /* Begin PBXFileReference section */
 		2DBA080D1F1FAD66001CFED4 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
+		3955D1782B3B05AF0037ABB6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3CA7D6C124592D4D005E10C2 /* ConstraintMakerRelatable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConstraintMakerRelatable+Extensions.swift"; sourceTree = "<group>"; };
 		537DCE9A1C35CD4100B5B899 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		5D64ABFF28D0878A00FFEC29 /* libswiftCoreGraphics.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libswiftCoreGraphics.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS16.0.sdk/usr/lib/swift/libswiftCoreGraphics.tbd; sourceTree = DEVELOPER_DIR; };
@@ -245,6 +246,7 @@
 				EE235F5C1C5785A400C08960 /* Models */,
 				EE235F5D1C5785AC00C08960 /* Debugging */,
 				EECDB3681AC0C95C006BBC11 /* Tests */,
+				3955D1782B3B05AF0037ABB6 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
I tried adding PrivacyInfo. I'm not sure if it's done right because I've never done PR before.

Below is a document listing API that Apple needs to add description. I checked and it didn't seem to be the case for Snapkit. 
[Describing use of required reason API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)
I would appreciate it if someone could double-check my findings to confirm their accuracy.

And I revised 'Package.swift' and 'SnapKit.podspec' by referring to the libraries that have already added PrivacyInfo.

But I'm not sure if this is the right thing to do. I want everyone to check it out together.

If you see anything that needs to be corrected, please share it with us.