### PR TITLE
Include privacy info for Cocoapods

### DIFF
--- a/SnapKit.podspec
+++ b/SnapKit.podspec
@@ -20,5 +20,9 @@ Pod::Spec.new do |s|
       'LIBRARY_SEARCH_PATHS' => '$(SDKROOT)/usr/lib/swift',
   }
 
+  s.resource_bundles = {
+    'SnapKit_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],
+  }
+
   s.swift_versions = ['5.0']
 end


### PR DESCRIPTION
Recently SnapKit introduced support for Privacy manifest but only for SPM. This PR introduces the support for Cocoapods based projects by adding using resource_bundles in the podspec.
While using `resources` can lead to collisions for resources with the same name, using `resource_bundles` is safe because it is the bundle that gets copied to the main app target, not the contents of the bundle themselves.

More details on the solution using resource_bundles can be found in this great comment in the Google promises repository, which is working on the same fix:

https://github.com/google/promises/pull/226#discussion_r1447871477