### PR TITLE
Reduce dynamic casts

### DIFF
--- a/Sources/ConstraintConstantTarget.swift
+++ b/Sources/ConstraintConstantTarget.swift
@@ -27,49 +27,88 @@
     import AppKit
 #endif
 
-
 public protocol ConstraintConstantTarget {
+    func asFloat() -> CGFloat?
+    func asSize() -> CGSize?
+    func asPoint() -> CGPoint?
+    func asConstraintInsets() -> ConstraintInsets?
+
+#if canImport(UIKit)
+    func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets?
+#endif
 }
 
 extension CGPoint: ConstraintConstantTarget {
+    public func asFloat() -> CGFloat? {
+        nil
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return self
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
-extension CGSize: ConstraintConstantTarget {    
+extension CGSize: ConstraintConstantTarget {
+    public func asFloat() -> CGFloat? {
+        nil
+    }
+    public func asSize() -> CGSize? {
+        return self
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
-extension ConstraintInsets: ConstraintConstantTarget {
-}
+extension ConstraintInsets: ConstraintConstantTarget {}
 
 #if canImport(UIKit)
 @available(iOS 11.0, tvOS 11.0, *)
 extension ConstraintDirectionalInsets: ConstraintConstantTarget {
+    public func asFloat() -> CGFloat? {
+        nil
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return self
+    }
 }
 #endif
 
 extension ConstraintConstantTarget {
-    
+
     internal func constraintConstantTargetValueFor(layoutAttribute: LayoutAttribute) -> CGFloat {
-        if let value = self as? CGFloat {
+        if let value = self.asFloat() {
             return value
         }
-        
-        if let value = self as? Float {
-            return CGFloat(value)
-        }
-        
-        if let value = self as? Double {
-            return CGFloat(value)
-        }
-        
-        if let value = self as? Int {
-            return CGFloat(value)
-        }
-        
-        if let value = self as? UInt {
-            return CGFloat(value)
-        }
-        
-        if let value = self as? CGSize {
+
+        if let value = self.asSize() {
             if layoutAttribute == .width {
                 return value.width
             } else if layoutAttribute == .height {
@@ -78,8 +117,8 @@ extension ConstraintConstantTarget {
                 return 0.0
             }
         }
-        
-        if let value = self as? CGPoint {
+
+        if let value = self.asPoint() {
             #if canImport(UIKit)
                 switch layoutAttribute {
                 case .left, .right, .leading, .trailing, .centerX, .leftMargin, .rightMargin, .leadingMargin, .trailingMargin, .centerXWithinMargins:
@@ -108,8 +147,8 @@ extension ConstraintConstantTarget {
             }
             #endif
         }
-        
-        if let value = self as? ConstraintInsets {
+
+        if let value = self.asConstraintInsets(){
             #if canImport(UIKit)
                 switch layoutAttribute {
                 case .left, .leftMargin:
@@ -170,9 +209,9 @@ extension ConstraintConstantTarget {
             }
             #endif
         }
-        
+
         #if canImport(UIKit)
-            if #available(iOS 11.0, tvOS 11.0, *), let value = self as? ConstraintDirectionalInsets {
+            if #available(iOS 11.0, tvOS 11.0, *), let value = self.asConstraintDirectionalInsets() {
                 switch layoutAttribute {
                 case .left, .leftMargin:
                   return (ConstraintConfig.interfaceLayoutDirection == .leftToRight) ? value.leading : value.trailing
@@ -209,5 +248,5 @@ extension ConstraintConstantTarget {
 
         return 0.0
     }
-    
+
 }

--- a/Sources/ConstraintConstantTarget.swift
+++ b/Sources/ConstraintConstantTarget.swift
@@ -43,17 +43,17 @@ extension CGPoint: ConstraintConstantTarget {
         nil
     }
     public func asSize() -> CGSize? {
-        return nil
+        nil
     }
     public func asPoint() -> CGPoint? {
-        return self
+        self
     }
     public func asConstraintInsets() -> ConstraintInsets? {
-        return nil
+        nil
     }
 #if canImport(UIKit)
     public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
-        return nil
+        nil
     }
 #endif
 }
@@ -63,17 +63,17 @@ extension CGSize: ConstraintConstantTarget {
         nil
     }
     public func asSize() -> CGSize? {
-        return self
+        self
     }
     public func asPoint() -> CGPoint? {
-        return nil
+        nil
     }
     public func asConstraintInsets() -> ConstraintInsets? {
-        return nil
+        nil
     }
 #if canImport(UIKit)
     public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
-        return nil
+        nil
     }
 #endif
 }
@@ -87,16 +87,16 @@ extension ConstraintDirectionalInsets: ConstraintConstantTarget {
         nil
     }
     public func asSize() -> CGSize? {
-        return nil
+        nil
     }
     public func asPoint() -> CGPoint? {
-        return nil
+        nil
     }
     public func asConstraintInsets() -> ConstraintInsets? {
-        return nil
+        nil
     }
     public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
-        return self
+        self
     }
 }
 #endif

--- a/Sources/ConstraintDSL.swift
+++ b/Sources/ConstraintDSL.swift
@@ -31,7 +31,8 @@
 public protocol ConstraintDSL {
     
     var target: AnyObject? { get }
-    
+    var layoutConstraintItem: LayoutConstraintItem? { get }
+
     func setLabel(_ value: String?)
     func label() -> String?
     
@@ -56,75 +57,75 @@ extension ConstraintBasicAttributesDSL {
     // MARK: Basics
     
     public var left: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.left)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.left)
     }
     
     public var top: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.top)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.top)
     }
     
     public var right: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.right)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.right)
     }
     
     public var bottom: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.bottom)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.bottom)
     }
     
     public var leading: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leading)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.leading)
     }
     
     public var trailing: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.trailing)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.trailing)
     }
     
     public var width: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.width)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.width)
     }
     
     public var height: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.height)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.height)
     }
     
     public var centerX: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerX)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.centerX)
     }
     
     public var centerY: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerY)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.centerY)
     }
     
     public var edges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.edges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.edges)
     }
     
     public var directionalEdges: ConstraintItem {
-      return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalEdges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.directionalEdges)
     }
 
     public var horizontalEdges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.horizontalEdges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.horizontalEdges)
     }
 
     public var verticalEdges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.verticalEdges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.verticalEdges)
     }
 
     public var directionalHorizontalEdges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalHorizontalEdges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.directionalHorizontalEdges)
     }
 
     public var directionalVerticalEdges: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalVerticalEdges)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.directionalVerticalEdges)
     }
 
     public var size: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.size)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.size)
     }
     
     public var center: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.center)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.center)
     }
     
 }
@@ -136,74 +137,82 @@ extension ConstraintAttributesDSL {
     // MARK: Baselines
     @available(*, deprecated, renamed:"lastBaseline")
     public var baseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.lastBaseline)
     }
     
     @available(iOS 8.0, OSX 10.11, *)
     public var lastBaseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.lastBaseline)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.lastBaseline)
     }
     
     @available(iOS 8.0, OSX 10.11, *)
     public var firstBaseline: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.firstBaseline)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.firstBaseline)
     }
     
     // MARK: Margins
     
     @available(iOS 8.0, *)
     public var leftMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leftMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.leftMargin)
     }
     
     @available(iOS 8.0, *)
     public var topMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.topMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.topMargin)
     }
     
     @available(iOS 8.0, *)
     public var rightMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.rightMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.rightMargin)
     }
     
     @available(iOS 8.0, *)
     public var bottomMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.bottomMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.bottomMargin)
     }
     
     @available(iOS 8.0, *)
     public var leadingMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.leadingMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.leadingMargin)
     }
     
     @available(iOS 8.0, *)
     public var trailingMargin: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.trailingMargin)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.trailingMargin)
     }
     
     @available(iOS 8.0, *)
     public var centerXWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerXWithinMargins)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.centerXWithinMargins)
     }
     
     @available(iOS 8.0, *)
     public var centerYWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerYWithinMargins)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.centerYWithinMargins)
     }
     
     @available(iOS 8.0, *)
     public var margins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.margins)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.margins)
     }
     
     @available(iOS 8.0, *)
     public var directionalMargins: ConstraintItem {
-      return ConstraintItem(target: self.target, attributes: ConstraintAttributes.directionalMargins)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.directionalMargins)
     }
 
     @available(iOS 8.0, *)
     public var centerWithinMargins: ConstraintItem {
-        return ConstraintItem(target: self.target, attributes: ConstraintAttributes.centerWithinMargins)
+        return makeConstraint(for: self, attributes: ConstraintAttributes.centerWithinMargins)
     }
     
+}
+
+private func makeConstraint(for dsl: ConstraintDSL, attributes: ConstraintAttributes) -> ConstraintItem {
+    if let item = dsl.layoutConstraintItem {
+        return ConstraintItem(layoutConstraintItem: item, attributes: attributes)
+    } else {
+        return ConstraintItem(target: dsl.target, attributes: attributes)
+    }
 }

--- a/Sources/ConstraintDescription.swift
+++ b/Sources/ConstraintDescription.swift
@@ -45,8 +45,8 @@ public class ConstraintDescription {
               let sourceLocation = self.sourceLocation else {
             return nil
         }
-        let from = ConstraintItem(target: self.item, attributes: self.attributes)
-        
+        let from = ConstraintItem(layoutConstraintItem: self.item, attributes: self.attributes)
+
         return Constraint(
             from: from,
             to: related,

--- a/Sources/ConstraintDirectionalInsetTarget.swift
+++ b/Sources/ConstraintDirectionalInsetTarget.swift
@@ -29,6 +29,7 @@ import AppKit
 
 #if canImport(UIKit)
 public protocol ConstraintDirectionalInsetTarget: ConstraintConstantTarget {
+    func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets?
 }
 
 @available(iOS 11.0, tvOS 11.0, *)
@@ -39,7 +40,7 @@ extension ConstraintDirectionalInsetTarget {
 
   @available(iOS 11.0, tvOS 11.0, *)
   internal var constraintDirectionalInsetTargetValue: ConstraintDirectionalInsets {
-    if let amount = self as? ConstraintDirectionalInsets {
+    if let amount = self.asConstraintDirectionalInsets() {
       return amount
     } else {
       return ConstraintDirectionalInsets(top: 0, leading: 0, bottom: 0, trailing: 0)

--- a/Sources/ConstraintInsetTarget.swift
+++ b/Sources/ConstraintInsetTarget.swift
@@ -32,41 +32,135 @@ public protocol ConstraintInsetTarget: ConstraintConstantTarget {
 }
 
 extension Int: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        CGFloat(self)
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension UInt: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        CGFloat(self)
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension Float: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        CGFloat(self)
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension Double: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        CGFloat(self)
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension CGFloat: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        self
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return nil
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension ConstraintInsets: ConstraintInsetTarget {
+    public func asFloat() -> CGFloat? {
+        nil
+    }
+    public func asSize() -> CGSize? {
+        return nil
+    }
+    public func asPoint() -> CGPoint? {
+        return nil
+    }
+    public func asConstraintInsets() -> ConstraintInsets? {
+        return self
+    }
+#if canImport(UIKit)
+    public func asConstraintDirectionalInsets() -> ConstraintDirectionalInsets? {
+        return nil
+    }
+#endif
 }
 
 extension ConstraintInsetTarget {
 
     internal var constraintInsetTargetValue: ConstraintInsets {
-        if let amount = self as? ConstraintInsets {
+        if let amount = self.asConstraintInsets() {
             return amount
-        } else if let amount = self as? Float {
-            return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? Double {
-            return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? CGFloat {
-            return ConstraintInsets(top: amount, left: amount, bottom: amount, right: amount)
-        } else if let amount = self as? Int {
-            return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
-        } else if let amount = self as? UInt {
+        } else if let amount = self.asFloat() {
             return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
         } else {
             return ConstraintInsets(top: 0, left: 0, bottom: 0, right: 0)
         }
     }
-    
+
 }

--- a/Sources/ConstraintInsetTarget.swift
+++ b/Sources/ConstraintInsetTarget.swift
@@ -157,7 +157,7 @@ extension ConstraintInsetTarget {
         if let amount = self.asConstraintInsets() {
             return amount
         } else if let amount = self.asFloat() {
-            return ConstraintInsets(top: CGFloat(amount), left: CGFloat(amount), bottom: CGFloat(amount), right: CGFloat(amount))
+            return ConstraintInsets(top: amount, left: amount, bottom: amount, right: amount)
         } else {
             return ConstraintInsets(top: 0, left: 0, bottom: 0, right: 0)
         }

--- a/Sources/ConstraintItem.swift
+++ b/Sources/ConstraintItem.swift
@@ -60,13 +60,13 @@ public func ==(lhs: ConstraintItem, rhs: ConstraintItem) -> Bool {
     guard lhs !== rhs else {
         return true
     }
-
+    
     // must both have valid targets and identical attributes
     guard let target1 = lhs.target,
           let target2 = rhs.target,
           target1 === target2 && lhs.attributes == rhs.attributes else {
             return false
     }
-
+    
     return true
 }

--- a/Sources/ConstraintItem.swift
+++ b/Sources/ConstraintItem.swift
@@ -29,19 +29,30 @@
 
 
 public final class ConstraintItem {
-    
+
     internal weak var target: AnyObject?
     internal let attributes: ConstraintAttributes
-    
+    internal weak var _layoutConstraintItem: LayoutConstraintItem?
+
     internal init(target: AnyObject?, attributes: ConstraintAttributes) {
         self.target = target
+        self._layoutConstraintItem = nil
         self.attributes = attributes
     }
-    
-    internal var layoutConstraintItem: LayoutConstraintItem? {
-        return self.target as? LayoutConstraintItem
+
+    internal init(layoutConstraintItem: LayoutConstraintItem?, attributes: ConstraintAttributes) {
+        self._layoutConstraintItem = layoutConstraintItem
+        self.target = layoutConstraintItem
+        self.attributes = attributes
     }
-    
+
+    internal var layoutConstraintItem: LayoutConstraintItem? {
+        if let value = _layoutConstraintItem {
+            return value
+        } else {
+            return nil
+        }
+    }
 }
 
 public func ==(lhs: ConstraintItem, rhs: ConstraintItem) -> Bool {
@@ -49,13 +60,13 @@ public func ==(lhs: ConstraintItem, rhs: ConstraintItem) -> Bool {
     guard lhs !== rhs else {
         return true
     }
-    
+
     // must both have valid targets and identical attributes
     guard let target1 = lhs.target,
           let target2 = rhs.target,
           target1 === target2 && lhs.attributes == rhs.attributes else {
             return false
     }
-    
+
     return true
 }

--- a/Sources/ConstraintLayoutGuideDSL.swift
+++ b/Sources/ConstraintLayoutGuideDSL.swift
@@ -52,6 +52,10 @@ public struct ConstraintLayoutGuideDSL: ConstraintAttributesDSL {
         ConstraintMaker.removeConstraints(item: self.guide)
     }
     
+    public var layoutConstraintItem: LayoutConstraintItem? {
+        return self.guide
+    }
+
     public var target: AnyObject? {
         return self.guide
     }

--- a/Sources/ConstraintLayoutSupportDSL.swift
+++ b/Sources/ConstraintLayoutSupportDSL.swift
@@ -30,6 +30,10 @@
 
 @available(iOS 8.0, *)
 public struct ConstraintLayoutSupportDSL: ConstraintDSL {
+
+    public var layoutConstraintItem: LayoutConstraintItem? {
+        return nil
+    }
     
     public var target: AnyObject? {
         return self.support

--- a/Sources/ConstraintMakerRelatable.swift
+++ b/Sources/ConstraintMakerRelatable.swift
@@ -40,7 +40,7 @@ public class ConstraintMakerRelatable {
         let related: ConstraintItem
         let constant: ConstraintConstantTarget
         
-        if let other = other as? ConstraintItem {
+        if let other = other.asConstraintItem() {
             guard other.attributes == ConstraintAttributes.none ||
                   other.attributes.layoutAttributes.count <= 1 ||
                   other.attributes.layoutAttributes == self.description.attributes.layoutAttributes ||
@@ -53,14 +53,14 @@ public class ConstraintMakerRelatable {
             
             related = other
             constant = 0.0
-        } else if let other = other as? ConstraintView {
-            related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
+        } else if let other = other.asConstraintView() {
+            related = ConstraintItem(layoutConstraintItem: other, attributes: ConstraintAttributes.none)
             constant = 0.0
-        } else if let other = other as? ConstraintConstantTarget {
-            related = ConstraintItem(target: nil, attributes: ConstraintAttributes.none)
+        } else if let other = other.asConstraintConstantTarget() {
+            related = ConstraintItem(layoutConstraintItem: nil, attributes: ConstraintAttributes.none)
             constant = other
-        } else if #available(iOS 9.0, OSX 10.11, *), let other = other as? ConstraintLayoutGuide {
-            related = ConstraintItem(target: other, attributes: ConstraintAttributes.none)
+        } else if #available(iOS 9.0, OSX 10.11, *), let other = other.asConstraintLayoutGuide() {
+            related = ConstraintItem(layoutConstraintItem: other, attributes: ConstraintAttributes.none)
             constant = 0.0
         } else {
             fatalError("Invalid constraint. (\(file), \(line))")

--- a/Sources/ConstraintOffsetTarget.swift
+++ b/Sources/ConstraintOffsetTarget.swift
@@ -49,21 +49,7 @@ extension CGFloat: ConstraintOffsetTarget {
 extension ConstraintOffsetTarget {
     
     internal var constraintOffsetTargetValue: CGFloat {
-        let offset: CGFloat
-        if let amount = self as? Float {
-            offset = CGFloat(amount)
-        } else if let amount = self as? Double {
-            offset = CGFloat(amount)
-        } else if let amount = self as? CGFloat {
-            offset = CGFloat(amount)
-        } else if let amount = self as? Int {
-            offset = CGFloat(amount)
-        } else if let amount = self as? UInt {
-            offset = CGFloat(amount)
-        } else {
-            offset = 0.0
-        }
-        return offset
+        asFloat() ?? 0
     }
     
 }

--- a/Sources/ConstraintRelatableTarget.swift
+++ b/Sources/ConstraintRelatableTarget.swift
@@ -29,44 +29,181 @@
 
 
 public protocol ConstraintRelatableTarget {
+    func asConstraintItem() -> ConstraintItem?
+    func asConstraintView() -> ConstraintView?
+    func asConstraintConstantTarget() -> ConstraintConstantTarget?
+    func asConstraintLayoutGuide() -> ConstraintLayoutGuide?
 }
 
 extension Int: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension UInt: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension Float: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension Double: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension CGFloat: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension CGSize: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension CGPoint: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension ConstraintInsets: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 #if canImport(UIKit)
 @available(iOS 11.0, tvOS 11.0, *)
 extension ConstraintDirectionalInsets: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        self
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 #endif
 
 extension ConstraintItem: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        self
+    }
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        nil
+    }
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 extension ConstraintView: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        nil
+    }
 }
 
 @available(iOS 9.0, OSX 10.11, *)
 extension ConstraintLayoutGuide: ConstraintRelatableTarget {
+    public func asConstraintItem() -> ConstraintItem? {
+        nil
+    }
+    public func asConstraintConstantTarget() -> ConstraintConstantTarget? {
+        nil
+    }
+
 }

--- a/Sources/ConstraintViewDSL.swift
+++ b/Sources/ConstraintViewDSL.swift
@@ -86,7 +86,11 @@ public struct ConstraintViewDSL: ConstraintAttributesDSL {
             self.view.setContentCompressionResistancePriority(LayoutPriority(rawValue: newValue), for: .vertical)
         }
     }
-    
+
+    public var layoutConstraintItem: LayoutConstraintItem? {
+        return self.view
+    }
+
     public var target: AnyObject? {
         return self.view
     }

--- a/Sources/LayoutConstraintItem.swift
+++ b/Sources/LayoutConstraintItem.swift
@@ -29,30 +29,46 @@
 
 
 public protocol LayoutConstraintItem: AnyObject {
+    func asConstraintView() -> ConstraintView?
+    func asConstraintLayoutGuide() -> ConstraintLayoutGuide?
 }
 
 @available(iOS 9.0, OSX 10.11, *)
 extension ConstraintLayoutGuide : LayoutConstraintItem {
+    public func asConstraintView() -> ConstraintView? {
+        nil
+    }
+
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        self
+    }
 }
 
 extension ConstraintView : LayoutConstraintItem {
+    public func asConstraintView() -> ConstraintView? {
+        self
+    }
+
+    public func asConstraintLayoutGuide() -> ConstraintLayoutGuide? {
+        nil
+    }
 }
 
 
 extension LayoutConstraintItem {
     
     internal func prepare() {
-        if let view = self as? ConstraintView {
+        if let view = self.asConstraintView() {
             view.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     
     internal var superview: ConstraintView? {
-        if let view = self as? ConstraintView {
+        if let view = self.asConstraintView() {
             return view.superview
         }
         
-        if #available(iOS 9.0, OSX 10.11, *), let guide = self as? ConstraintLayoutGuide {
+        if #available(iOS 9.0, OSX 10.11, *), let guide = self.asConstraintLayoutGuide() {
             return guide.owningView
         }
         


### PR DESCRIPTION
# Description
This pull requests replaces dynamicCasts (`as?`) with protocol method calls

# Motivation
In our company we heavily rely on SnapKit. So my team and I have investigated `SnapKit` performance in extremely-large apps. We discovered that `dynamicCasts` have significant performance impact on `SnapKit` performance: about 5/6 of time taken by `Constraint.init` (and its call-tree) is occupied by `dynamic_cast_existential_1_conditional`.  All measurements were made by opening the most important and visited screens in our iOS app.

Before optimisations:

<img width="1401" alt="SnapKit-Before" src="https://github.com/SnapKit/SnapKit/assets/18101676/6334cb18-f1e5-4336-851d-fd9431ead95d">


After optimisations:
<img width="1400" alt="SnapKit-After" src="https://github.com/SnapKit/SnapKit/assets/18101676/6aa1310a-0b35-446f-ab95-02ac92173f2e">


# Changes Made
Extended some protocols with new methods that are used to avoid using `as?`.
Also, we've successfully avoided breaking ABI (at least in our project).

This Pull Request doesn't require to change call site: `ConstraintItem.init` is `internal` and I doubt that somebody has class or struct conforming to `ConstraintConstantTarget`, `ConstraintDSL`, `ConstraintRelatableTarget` or `ConstraintInsetTarget`.

# Testing Done
- Compiled for iOS and macOS
- Checked basic layout in Example app
- Checked complex layouts in our app
- Ran unit-tests locally


Please review this pull request and provide feedback. Thanks in advance!
