### PR TITLE
Remove explicit 'make' label from constraint closures

### DIFF
--- a/Sources/ConstraintLayoutGuideDSL.swift
+++ b/Sources/ConstraintLayoutGuideDSL.swift
@@ -32,19 +32,19 @@
 public struct ConstraintLayoutGuideDSL: ConstraintAttributesDSL {
     
     @discardableResult
-    public func prepareConstraints(_ closure: (_ make: ConstraintMaker) -> Void) -> [Constraint] {
+    public func prepareConstraints(_ closure: (ConstraintMaker) -> Void) -> [Constraint] {
         return ConstraintMaker.prepareConstraints(item: self.guide, closure: closure)
     }
     
-    public func makeConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func makeConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.makeConstraints(item: self.guide, closure: closure)
     }
     
-    public func remakeConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func remakeConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.remakeConstraints(item: self.guide, closure: closure)
     }
     
-    public func updateConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func updateConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.updateConstraints(item: self.guide, closure: closure)
     }
     

--- a/Sources/ConstraintMaker.swift
+++ b/Sources/ConstraintMaker.swift
@@ -177,7 +177,7 @@ public class ConstraintMaker {
         return ConstraintMakerExtendable(description)
     }
     
-    internal static func prepareConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) -> [Constraint] {
+    internal static func prepareConstraints(item: LayoutConstraintItem, closure: (ConstraintMaker) -> Void) -> [Constraint] {
         let maker = ConstraintMaker(item: item)
         closure(maker)
         var constraints: [Constraint] = []
@@ -190,19 +190,19 @@ public class ConstraintMaker {
         return constraints
     }
     
-    internal static func makeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    internal static func makeConstraints(item: LayoutConstraintItem, closure: (ConstraintMaker) -> Void) {
         let constraints = prepareConstraints(item: item, closure: closure)
         for constraint in constraints {
             constraint.activateIfNeeded(updatingExisting: false)
         }
     }
     
-    internal static func remakeConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    internal static func remakeConstraints(item: LayoutConstraintItem, closure: (ConstraintMaker) -> Void) {
         self.removeConstraints(item: item)
         self.makeConstraints(item: item, closure: closure)
     }
     
-    internal static func updateConstraints(item: LayoutConstraintItem, closure: (_ make: ConstraintMaker) -> Void) {
+    internal static func updateConstraints(item: LayoutConstraintItem, closure: (ConstraintMaker) -> Void) {
         guard item.constraints.count > 0 else {
             self.makeConstraints(item: item, closure: closure)
             return

--- a/Sources/ConstraintViewDSL.swift
+++ b/Sources/ConstraintViewDSL.swift
@@ -31,19 +31,19 @@
 public struct ConstraintViewDSL: ConstraintAttributesDSL {
     
     @discardableResult
-    public func prepareConstraints(_ closure: (_ make: ConstraintMaker) -> Void) -> [Constraint] {
+    public func prepareConstraints(_ closure: (ConstraintMaker) -> Void) -> [Constraint] {
         return ConstraintMaker.prepareConstraints(item: self.view, closure: closure)
     }
     
-    public func makeConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func makeConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.makeConstraints(item: self.view, closure: closure)
     }
     
-    public func remakeConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func remakeConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.remakeConstraints(item: self.view, closure: closure)
     }
     
-    public func updateConstraints(_ closure: (_ make: ConstraintMaker) -> Void) {
+    public func updateConstraints(_ closure: (ConstraintMaker) -> Void) {
         ConstraintMaker.updateConstraints(item: self.view, closure: closure)
     }
     


### PR DESCRIPTION
### Motivation

The current function signatures for makeConstraints and similar methods explicitly name the closure parameter make, as in (_ make: ConstraintMaker) -> Void. This forces Xcode to hardcode make in during autocompletion. 

For developers who prefer Swift's shorthand $0 syntax, this workflow interrupts their coding flow with unnecessary keystrokes or mouse movements just to remove the 'make in' text. 

-----

### Changes

This PR provides a more flexible autocompletion that allows developers to easily use the shorthand $0 syntax, rename the parameter.

  * **Before:** `(_ make: ConstraintMaker) -> Void`
  * **After:** `(ConstraintMaker) -> Void`

#### Example Workflow

**Current Workflow:**
A developer wanting to use `$0` must manually delete the `make in` provided by autocompletion.

```swift
// 1. Autocompletes to this:
view.snp.makeConstraints { make in
    // 2. Developer must stop and perform extra actions
    //    (e.g., mouse drag + delete, or multiple keystrokes)
    //    to remove "make in".
}
```

**Improved Workflow with this PR:**
The new autocompletion provides a placeholder, which can be easily deleted to use shorthand syntax.

```swift
// 1. Autocompletes to this, with the placeholder selected:
view.snp.makeConstraints { <#ConstraintMaker#> in
    
}

// 2. A single backspace removes the placeholder, ready for shorthand syntax.
view.snp.makeConstraints {
    $0.edges.equalToSuperview()
}
```
