### PR TITLE
Support AppKit layout priorities

### DIFF
--- a/Sources/ConstraintPriorityTarget.swift
+++ b/Sources/ConstraintPriorityTarget.swift
@@ -82,4 +82,12 @@ extension UILayoutPriority: ConstraintPriorityTarget {
     }
 
 }
+#else
+extension NSLayoutConstraint.Priority: ConstraintPriorityTarget {
+
+    public var constraintPriorityTargetValue: Float {
+        return self.rawValue
+    }
+
+}
 #endif


### PR DESCRIPTION
I added AppKit parity for SnapKit priority targets.

`NSLayoutConstraint.Priority` now conforms to `ConstraintPriorityTarget` on AppKit, matching the existing UIKit `UILayoutPriority` support. This lets macOS callers pass native layout priorities directly to SnapKit priority APIs.

Validation:
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift build`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift test`
- standalone typecheck with `NSLayoutConstraint.Priority.defaultLow` as `ConstraintPriorityTarget`