### PR TITLE
[codex] Fix deprecated priority update helpers

### DIFF
--- a/Sources/Constraint.swift
+++ b/Sources/Constraint.swift
@@ -276,16 +276,16 @@ public final class Constraint {
     public func updatePriority(amount: ConstraintPriorityTarget) -> Void { self.update(priority: amount) }
 
     @available(*, deprecated, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityRequired() -> Void {}
+    public func updatePriorityRequired() -> Void { self.update(priority: ConstraintPriority.required) }
 
     @available(*, deprecated, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityHigh() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityHigh() -> Void { self.update(priority: ConstraintPriority.high) }
 
     @available(*, deprecated, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityMedium() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityMedium() -> Void { self.update(priority: ConstraintPriority.medium) }
 
     @available(*, deprecated, message:"Use update(priority: ConstraintPriorityTarget) instead.")
-    public func updatePriorityLow() -> Void { fatalError("Must be implemented by Concrete subclass.") }
+    public func updatePriorityLow() -> Void { self.update(priority: ConstraintPriority.low) }
 
     // MARK: Internal
 


### PR DESCRIPTION
## Summary

This updates the deprecated `Constraint` priority helper methods so they continue to behave like the replacement API.

`updatePriorityRequired()`, `updatePriorityHigh()`, `updatePriorityMedium()`, and `updatePriorityLow()` now delegate to `update(priority:)` with the matching `ConstraintPriority` value. Previously the required helper was a no-op, while the high, medium, and low helpers crashed unconditionally.

## Impact

Projects still using these deprecated helpers can update constraint priority without runtime crashes while receiving the existing deprecation guidance.

## Validation

- `swift test` could not start with the active Command Line Tools SwiftPM because `BuildServerProtocol.framework` was missing.
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --disable-sandbox` passed with 25 tests and 0 failures.
